### PR TITLE
Fix not Resetting

### DIFF
--- a/Scripts/global.gd
+++ b/Scripts/global.gd
@@ -16,6 +16,9 @@ func turn_task_4_interact():
 func reset_var():
 	ads = 0
 	task_4_remove_task = []
+	task_4_remove_task = Dictionary()
+	task_4_interact = Dictionary()
+	task_4_interact_email_button = ""
 	task_2_remove_task = Dictionary()
 	task_2_interact = Dictionary()
 	task_2_interact_email_button = ""
@@ -267,9 +270,6 @@ var users = {
 				"like": "520"
 			}
 		}
-	}
-}
-
 # Dictionary containing power-up data
 var power_ups = {
 	0: {


### PR DESCRIPTION
Fix not Resetting at Task 4

## Summary by Sourcery

Fix Task 4 reset logic by properly initializing its variables and correct a syntax error in the users data structure.

Bug Fixes:
- Initialize task_4_remove_task, task_4_interact, and task_4_interact_email_button in reset_var to ensure Task 4 state is cleared.
- Remove extraneous closing braces from the users dictionary to fix script syntax.